### PR TITLE
Use HttpSession to keep user institution scope

### DIFF
--- a/src/org/lockss/account/UserAccount.java
+++ b/src/org/lockss/account/UserAccount.java
@@ -89,8 +89,6 @@ public abstract class UserAccount implements LockssSerializable, Comparable {
   protected transient Credential credential = null;
   protected transient boolean isChanged = false;
   protected transient StringBuilder eventsToReport;
-  
-  private String institutionScope;
 
   public UserAccount(String name) {
     this.userName = name;
@@ -745,15 +743,7 @@ public abstract class UserAccount implements LockssSerializable, Comparable {
     return getName().compareTo(other.getName());
   }
 
-  public String getInstitutionScope() {
-    return institutionScope;
-}
-
-public void setInstitutionScope(String institutionScope) {
-    this.institutionScope = institutionScope;
-}
-
-public class NullCredential extends Credential {
+  public class NullCredential extends Credential {
     public boolean check(Object credentials) {
       return false;
     }

--- a/src/org/lockss/servlet/SafeNetServeContent.java
+++ b/src/org/lockss/servlet/SafeNetServeContent.java
@@ -402,25 +402,25 @@ public class SafeNetServeContent extends LockssServlet {
    */
   public void lockssHandleRequest() throws IOException {
     
-    // Redirect user to ediauth login page if doesn't have a institution allocated
-    UserAccount user = getUserAccount();
-    if( user.getInstitutionScope() == null ){
-      String token = req.getParameter("ediauthToken");
-      if(token != null){
-        // Reassign userAccount
-        String userInstScope = this.getAccountManager().getFromMapToken(token);
-        
-        // UserAccount user = getUserAccount();
-        log.debug("Assigning inst. scope to user:"+userInstScope);
-        user.setInstitutionScope(userInstScope);
-      } else {
-        log.debug("Redirecting user to ediauth...");
-        resp.sendRedirect(ediauthUrl);
-        return;
-      }
-    } else {
-      log.debug("User already have inst. allocated!");
-    }
+      
+	  // Redirect user to ediauth login page if doesn't have a institution allocated
+	  if( this.getSession().getAttribute("scope") == null ){
+	    String token = req.getParameter("ediauthToken");
+	    if(token != null){
+	      // Reassign userAccount
+	      String userInstScope = this.getAccountManager().getFromMapToken(token);
+	      
+	      // UserAccount user = getUserAccount();
+	      log.debug("Assigning inst. scope to user:"+userInstScope);
+	      this.getSession().setAttribute("scope", userInstScope);
+	    } else {
+	      log.debug("Redirecting user to ediauth: "+ediauthUrl);
+	      resp.sendRedirect(ediauthUrl);
+	      return;
+	    }
+	  } else {
+	    log.debug("User already have inst. allocated!");
+	  }
       
     if (!pluginMgr.areAusStarted()) {
       displayNotStarted();
@@ -2102,8 +2102,7 @@ public class SafeNetServeContent extends LockssServlet {
     }
     Page page = newPage();
     
-    UserAccount user = getUserAccount();
-    String scope = user.getInstitutionScope();
+    String scope = (String)this.getSession().getAttribute("scope");
     if(scope != null) {
       page.add("User inst: " + scope);
     } else {
@@ -2206,7 +2205,7 @@ public class SafeNetServeContent extends LockssServlet {
   void updateInstitution() throws IOException {
       //This is currently called in lockssHandleRequest, it needs to be called from wherever we do the SAML authentication
 //      institutionScope = "ed.ac.uk";
-      String scope = getUserAccount().getInstitutionScope();
+      String scope = (String)this.getSession().getAttribute("scope");
       institution = entitlementRegistry.getInstitution(scope);
   }
 


### PR DESCRIPTION
- Remove the institutionScope field from UserAccount.java
- Modify SafeNetServeContent in order to use the servlet session to save the institution scope

N.B.: We are still using the AccountManager object to save the token used to keep track of users which have been through ediauth authentication.
