### PR TITLE
Access Ediauth from test IdPs

### DIFF
--- a/src/org/lockss/servlet/EdiauthLogin.java
+++ b/src/org/lockss/servlet/EdiauthLogin.java
@@ -33,9 +33,13 @@ public class EdiauthLogin extends LockssServlet {
   /** Ediauth configuration **/
   public static final String PARAM_EDIAUTH_IP = PREFIX + "ediauthUrl";
   public static final String PARAM_EDIAUTH_REDIRECT_URL = PREFIX + "returnURL";
+  /* List of IdPs that are allowed to access the service without presenting a shibbAccountable parameter
+   * This should only be set for testing purposes */
+  public static final String PARAM_EDIAUTH_ALLOWED_NON_ACCOUNTABLE_IDPS = PREFIX + "allowedNonAccountableIdPs";
   
   private static String ediauthIP;
   private static String ediauthReturnURL;
+  private static List<String> allowedNonAccountableIdPs;
 
   public void init(ServletConfig config) throws ServletException {
     super.init(config);
@@ -48,6 +52,7 @@ public class EdiauthLogin extends LockssServlet {
     if (diffs.contains(PREFIX)) {
       ediauthIP = config.get(PARAM_EDIAUTH_IP);
       ediauthReturnURL = config.get(PARAM_EDIAUTH_REDIRECT_URL);
+      allowedNonAccountableIdPs = config.getList(PARAM_EDIAUTH_ALLOWED_NON_ACCOUNTABLE_IDPS);
     }
   }
 
@@ -106,6 +111,12 @@ public class EdiauthLogin extends LockssServlet {
          * rules-of-membership.pdf
          */
         boolean accountable = "1".equals(map.get("shibbAccountable"));
+        if (!accountable) {
+            String idp = map.get("shibbIdP");
+            if (idp != null) {
+                accountable = allowedNonAccountableIdPs.contains(idp);
+            }
+        }
         boolean requireAccountable = true; // this is up to you.
 
         /*

--- a/src/org/lockss/servlet/EdiauthLogin.java
+++ b/src/org/lockss/servlet/EdiauthLogin.java
@@ -105,7 +105,7 @@ public class EdiauthLogin extends LockssServlet {
          * http://www.ukfederation.org.uk/library/uploads/Documents/
          * rules-of-membership.pdf
          */
-        boolean accountable = Integer.valueOf(map.get("shibbAccountable")) == 1;
+        boolean accountable = "1".equals(map.get("shibbAccountable"));
         boolean requireAccountable = true; // this is up to you.
 
         /*


### PR DESCRIPTION
I've been trying to write some end-to-end tests for SafeNetServeContent, and I wanted to use the UK federation test IdP rather than hard-coding in my Edinburgh credentials. I worked through this with Ben, and we managed to come up with a few issues, which should be sorted here.
- The ediauth server was rejecting requests for IdPs that don't have an edinaOrgID. This has been removed, as we don't need to know about institutions prior to them using SafeNet
- The servlet was choking with a NumberFormatException if shibbAccountable wasn't provided
- We don't want to accept users from IdPs that aren't accountable, but for test purposes I've added a configuration parameter that can be set, so that on our test instance we can add https://test-idp.ukfederation.org.uk/idp/shibboleth, but not on any eventual live instance
