### PR TITLE
Use AUs that contain the CU, not those that match the crawl rules

### DIFF
--- a/src/org/lockss/servlet/SafeNetServeContent.java
+++ b/src/org/lockss/servlet/SafeNetServeContent.java
@@ -129,9 +129,8 @@ public class SafeNetServeContent extends ServeContent {
   }
 
   protected boolean setCachedUrlAndAu() throws IOException {
-    // Find a CU that the user is entitled to access, and with content if possible.  If none, find an AU where
-    // it would fit so can rewrite content from publisher if necessary.
-    List<CachedUrl> cachedUrls = pluginMgr.findCachedUrls(url, CuContentReq.PreferContent);
+    // Find a CU that the user is entitled to access, and with content
+    List<CachedUrl> cachedUrls = pluginMgr.findCachedUrls(url, CuContentReq.HasContent);
     if(cachedUrls != null && !cachedUrls.isEmpty()) {
       for(CachedUrl cachedUrl: cachedUrls) {
         try {


### PR DESCRIPTION
Default ServeContent tries to find AUs that _could_ fit the desired URL,
but does this by using the AU's crawl rules, which are non-specific and
can match items for other AUs. This means that e.g. /issue/view/2 would
match the AU for Volume 1 & Volume 2, despite only being cached for
Volume 2. 

What this means is that users could actually get access to content they weren't entitled to, if they were entitled to other volumes for the same journal
