### PR TITLE
Updated to match the fact that publishers in the ER are now linked to…

### DIFF
--- a/src/org/lockss/safenet/CachingEntitlementRegistryClient.java
+++ b/src/org/lockss/safenet/CachingEntitlementRegistryClient.java
@@ -41,11 +41,11 @@ public class CachingEntitlementRegistryClient extends BaseLockssManager implemen
     return (Boolean) result;
   }
 
-  public String getPublisher(String issn, String start, String end) throws IOException {
-    Object result = this.cache.get("getPublisher", issn, start, end);
+  public String getPublisher(String issn, String institution, String start, String end) throws IOException {
+    Object result = this.cache.get("getPublisher", issn, institution, start, end);
     if(result == null) {
-        result = this.client.getPublisher(issn, start, end);
-        this.cache.put("getPublisher", issn, start, end, result);
+        result = this.client.getPublisher(issn, institution, start, end);
+        this.cache.put("getPublisher", issn, institution, start, end, result);
     }
     return (String) result;
   }

--- a/src/org/lockss/safenet/EntitlementRegistryClient.java
+++ b/src/org/lockss/safenet/EntitlementRegistryClient.java
@@ -7,6 +7,6 @@ import org.lockss.app.LockssManager;
 public interface EntitlementRegistryClient extends LockssManager {
   boolean isUserEntitled(String issn, String institution, String start, String end) throws IOException;
   String getInstitution(String scope) throws IOException;
-  String getPublisher(String issn, String start, String end) throws IOException;
+  String getPublisher(String issn, String institution, String start, String end) throws IOException;
   PublisherWorkflow getPublisherWorkflow(String publisherGuid) throws IOException;
 }

--- a/src/org/lockss/servlet/SafeNetServeContent.java
+++ b/src/org/lockss/servlet/SafeNetServeContent.java
@@ -257,7 +257,7 @@ public class SafeNetServeContent extends ServeContent {
       }
       String start = tdbAu.getStartYear() + "0101";
       String end = tdbAu.getEndYear() + "1231";
-      
+
       return entitlementRegistry.isUserEntitled(issn, institution, start, end);
   }
 
@@ -270,7 +270,7 @@ public class SafeNetServeContent extends ServeContent {
       String start = tdbAu.getStartYear() + "0101";
       String end = tdbAu.getEndYear() + "1231";
 
-      String publisher = entitlementRegistry.getPublisher(issn, start, end);
+      String publisher = entitlementRegistry.getPublisher(issn, institution, start, end);
       if(StringUtil.isNullString(publisher)) {
         throw new IllegalArgumentException("No publisher found");
       }

--- a/test/src/org/lockss/safenet/TestCachingEntitlementRegistryClient.java
+++ b/test/src/org/lockss/safenet/TestCachingEntitlementRegistryClient.java
@@ -27,8 +27,8 @@ public class TestCachingEntitlementRegistryClient extends LockssTestCase {
     Mockito.when(mock.isUserEntitled("0000-0000", "11111111-1111-1111-1111-111111111111", "20120101", "20151231")).thenReturn(true);
     Mockito.when(mock.isUserEntitled("0000-0001", "11111111-1111-1111-1111-111111111111", "20120101", "20151231")).thenReturn(false);
     Mockito.when(mock.isUserEntitled("0000-0002", "11111111-1111-1111-1111-111111111111", "20120101", "20151231")).thenThrow(new IOException("Error communicating with entitlement registry. Response was 500 null"));
-    Mockito.when(mock.getPublisher("0000-0000", "20120101", "20151231")).thenReturn("33333333-0000-0000-0000-000000000000");
-    Mockito.when(mock.getPublisher("0000-0001", "20120101", "20151231")).thenReturn("33333333-0000-0000-0000-000000000001");
+    Mockito.when(mock.getPublisher("0000-0000", "11111111-1111-1111-1111-111111111111", "20120101", "20151231")).thenReturn("33333333-0000-0000-0000-000000000000");
+    Mockito.when(mock.getPublisher("0000-0001", "11111111-1111-1111-1111-111111111111", "20120101", "20151231")).thenReturn("33333333-0000-0000-0000-000000000001");
     Mockito.when(mock.getPublisherWorkflow("33333333-0000-0000-0000-000000000000")).thenReturn(PublisherWorkflow.PRIMARY_SAFENET);
     Mockito.when(mock.getPublisherWorkflow("33333333-1111-1111-1111-111111111111")).thenReturn(PublisherWorkflow.PRIMARY_PUBLISHER);
 
@@ -41,15 +41,15 @@ public class TestCachingEntitlementRegistryClient extends LockssTestCase {
     catch(IOException e) {
       assertEquals("Error communicating with entitlement registry. Response was 500 null", e.getMessage());
     }
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0000-0000", "20120101", "20151231"));
-    assertEquals("33333333-0000-0000-0000-000000000001", client.getPublisher("0000-0001", "20120101", "20151231"));
+    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0000-0000", "11111111-1111-1111-1111-111111111111", "20120101", "20151231"));
+    assertEquals("33333333-0000-0000-0000-000000000001", client.getPublisher("0000-0001", "11111111-1111-1111-1111-111111111111", "20120101", "20151231"));
     assertEquals(PublisherWorkflow.PRIMARY_SAFENET, client.getPublisherWorkflow("33333333-0000-0000-0000-000000000000"));
     assertEquals(PublisherWorkflow.PRIMARY_PUBLISHER, client.getPublisherWorkflow("33333333-1111-1111-1111-111111111111"));
 
     assertEquals(PublisherWorkflow.PRIMARY_PUBLISHER, client.getPublisherWorkflow("33333333-1111-1111-1111-111111111111"));
     assertEquals(PublisherWorkflow.PRIMARY_SAFENET, client.getPublisherWorkflow("33333333-0000-0000-0000-000000000000"));
-    assertEquals("33333333-0000-0000-0000-000000000001", client.getPublisher("0000-0001", "20120101", "20151231"));
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0000-0000", "20120101", "20151231"));
+    assertEquals("33333333-0000-0000-0000-000000000001", client.getPublisher("0000-0001", "11111111-1111-1111-1111-111111111111", "20120101", "20151231"));
+    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0000-0000", "11111111-1111-1111-1111-111111111111", "20120101", "20151231"));
     try {
       client.isUserEntitled("0000-0002", "11111111-1111-1111-1111-111111111111", "20120101", "20151231");
       fail("Expected exception not thrown");
@@ -63,8 +63,8 @@ public class TestCachingEntitlementRegistryClient extends LockssTestCase {
     Mockito.verify(mock, Mockito.times(2)).isUserEntitled("0000-0000", "11111111-1111-1111-1111-111111111111", "20120101", "20151231");
     Mockito.verify(mock).isUserEntitled("0000-0001", "11111111-1111-1111-1111-111111111111", "20120101", "20151231");
     Mockito.verify(mock, Mockito.times(2)).isUserEntitled("0000-0002", "11111111-1111-1111-1111-111111111111", "20120101", "20151231");
-    Mockito.verify(mock).getPublisher("0000-0000", "20120101", "20151231");
-    Mockito.verify(mock).getPublisher("0000-0001", "20120101", "20151231");
+    Mockito.verify(mock).getPublisher("0000-0000", "11111111-1111-1111-1111-111111111111", "20120101", "20151231");
+    Mockito.verify(mock).getPublisher("0000-0001", "11111111-1111-1111-1111-111111111111", "20120101", "20151231");
     Mockito.verify(mock).getPublisherWorkflow("33333333-0000-0000-0000-000000000000");
     Mockito.verify(mock).getPublisherWorkflow("33333333-1111-1111-1111-111111111111");
   }

--- a/test/src/org/lockss/safenet/TestEntitlementRegistryClient.java
+++ b/test/src/org/lockss/safenet/TestEntitlementRegistryClient.java
@@ -28,6 +28,7 @@ public class TestEntitlementRegistryClient extends LockssTestCase {
   private BaseEntitlementRegistryClient client;
 
   private Map<String,String> validEntitlementParams;
+  private Map<String,String> validResponseParams;
   private Map<String,String> validPublisherParams;
 
   public void setUp() throws Exception {
@@ -49,6 +50,10 @@ public class TestEntitlementRegistryClient extends LockssTestCase {
     validEntitlementParams.put("institution", "11111111-1111-1111-1111-111111111111");
     validEntitlementParams.put("start", "20120101");
     validEntitlementParams.put("end", "20151231");
+
+    validResponseParams = new HashMap<String,String>(validEntitlementParams);
+    validResponseParams.remove("api_key");
+    validResponseParams.put("publisher", "33333333-0000-0000-0000-000000000000");
 
     validPublisherParams = new HashMap<String, String>();
     validPublisherParams.put("id", "33333333-0000-0000-0000-000000000000");
@@ -112,10 +117,8 @@ public class TestEntitlementRegistryClient extends LockssTestCase {
   }
 
   public void testUserEntitled() throws Exception {
-    Map<String, String> responseParams = new HashMap<String,String>(validEntitlementParams);
-    responseParams.remove("api_key");
     String url = url("/entitlements", BaseEntitlementRegistryClient.mapToPairs(validEntitlementParams));
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
+    Mockito.doReturn(connection(url, 200, "[" + mapToJson(validResponseParams) + "]")).when(client).openConnection(url);
 
     assertTrue(client.isUserEntitled("0123-456X", "11111111-1111-1111-1111-111111111111", "20120101", "20151231"));
     Mockito.verify(client).openConnection(url);
@@ -187,154 +190,18 @@ public class TestEntitlementRegistryClient extends LockssTestCase {
   }
 
   public void testGetPublisher() throws Exception {
-    Map<String, String> queryParams = new HashMap<String, String>();
-    queryParams.put("identifier", "0123-456X");
-    Map<String, String> publisher = new HashMap<String, String>();
-    publisher.put("id", "33333333-0000-0000-0000-000000000000");
-    publisher.put("start", null);
-    publisher.put("end", null);
-    List<Map<String, String>> publishers = new ArrayList<Map<String, String>>();
-    publishers.add(publisher);
-    Map<String, Object> responseParams = new HashMap<String, Object>();
-    responseParams.put("publishers", publishers);
+    String url = url("/entitlements", BaseEntitlementRegistryClient.mapToPairs(validEntitlementParams));
+    Mockito.doReturn(connection(url, 200, "[" + mapToJson(validResponseParams) + "]")).when(client).openConnection(url);
 
-    String url = url("/titles", BaseEntitlementRegistryClient.mapToPairs(queryParams));
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", "20120101", "20151231"));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", null, "20151231"));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", "20120101", null));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", null, null));
-
-    Mockito.verify(client, Mockito.times(4)).openConnection(url);
-  }
-
-  public void testGetPublisherDateLimited() throws Exception {
-    Map<String, String> queryParams = new HashMap<String, String>();
-    queryParams.put("identifier", "0123-456X");
-    Map<String, String> publisher = new HashMap<String, String>();
-    publisher.put("id", "33333333-0000-0000-0000-000000000000");
-    publisher.put("start", "20120101");
-    publisher.put("end", "20151231");
-
-    List<Map<String, String>> publishers = new ArrayList<Map<String, String>>();
-    publishers.add(publisher);
-    Map<String, Object> responseParams = new HashMap<String, Object>();
-    responseParams.put("publishers", publishers);
-
-    String url = url("/titles", BaseEntitlementRegistryClient.mapToPairs(queryParams));
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", "20120101", "20151231"));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals(null, client.getPublisher("0123-456X", "20111231", "20151231"));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals(null, client.getPublisher("0123-456X", "20120101", "20160101"));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", "20120102", "20151230"));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals(null, client.getPublisher("0123-456X", null, "20151231"));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals(null, client.getPublisher("0123-456X", "20120101", null));
-
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals(null, client.getPublisher("0123-456X", null, null));
-
-    Mockito.verify(client, Mockito.times(7)).openConnection(url);
-  }
-
-  public void testGetPublisherNoResponse() throws Exception {
-    Map<String, String> queryParams = new HashMap<String, String>();
-    queryParams.put("identifier", "0123-456X");
-    String url = url("/titles", BaseEntitlementRegistryClient.mapToPairs(queryParams));
-    Mockito.doReturn(connection(url, 200, "[]")).when(client).openConnection(url);
-    assertEquals(null, client.getPublisher("0123-456X", "20120101", "20151231"));
-  }
-
-  private List<Map<String, String>> getMultiplePublishers() {
-    Map<String, String> publisher = new HashMap<String, String>();
-    publisher.put("id", "33333333-0000-0000-0000-000000000000");
-    publisher.put("start", "20120101");
-    publisher.put("end", "20151231");
-    Map<String, String> publisher2 = new HashMap<String, String>();
-    publisher2.put("id", "33333333-1111-1111-1111-111111111111");
-    publisher2.put("start", "20160101");
-    publisher2.put("end", null);
-    List<Map<String, String>> publishers = new ArrayList<Map<String, String>>();
-    publishers.add(publisher);
-    publishers.add(publisher2);
-    return publishers;
-  }
-
-  public void testGetPublisherMultipleResponses() throws Exception {
-    Map<String, String> queryParams = new HashMap<String, String>();
-    queryParams.put("identifier", "0123-456X");
-    Map<String, Object> responseParams = new HashMap<String, Object>();
-    List<Map<String, String>> publishers = getMultiplePublishers();
-    responseParams.put("publishers", publishers);
-
-    String url = url("/titles", BaseEntitlementRegistryClient.mapToPairs(queryParams));
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", "20150101", "20151231"));
-
+    assertEquals("33333333-0000-0000-0000-000000000000", client.getPublisher("0123-456X", "11111111-1111-1111-1111-111111111111", "20120101", "20151231"));
     Mockito.verify(client).openConnection(url);
   }
 
-  public void testGetPublisherMultipleResponses2() throws Exception {
-    Map<String, String> queryParams = new HashMap<String, String>();
-    queryParams.put("identifier", "0123-456X");
-    Map<String, Object> responseParams = new HashMap<String, Object>();
-    List<Map<String, String>> publishers = getMultiplePublishers();
-    responseParams.put("publishers", publishers);
+  public void testGetPublisherNotEntitled() throws Exception {
+    String url = url("/entitlements", BaseEntitlementRegistryClient.mapToPairs(validEntitlementParams));
+    Mockito.doReturn(connection(url, 204, "")).when(client).openConnection(url);
 
-    String url = url("/titles", BaseEntitlementRegistryClient.mapToPairs(queryParams));
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals("33333333-1111-1111-1111-111111111111", client.getPublisher("0123-456X", "20160101", "20161231"));
-
-    Mockito.verify(client).openConnection(url);
-  }
-
-  public void testGetPublisherMultipleResponsesOutsideRange() throws Exception {
-    Map<String, String> queryParams = new HashMap<String, String>();
-    queryParams.put("identifier", "0123-456X");
-    Map<String, Object> responseParams = new HashMap<String, Object>();
-    List<Map<String, String>> publishers = getMultiplePublishers();
-    responseParams.put("publishers", publishers);
-
-    String url = url("/titles", BaseEntitlementRegistryClient.mapToPairs(queryParams));
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    assertEquals(null, client.getPublisher("0123-456X", "20150101", "20161231"));
-
-    Mockito.verify(client).openConnection(url);
-  }
-
-  public void testGetPublisherMultipleResponsesMultipleMatching() throws Exception {
-    Map<String, String> queryParams = new HashMap<String, String>();
-    queryParams.put("identifier", "0123-456X");
-    Map<String, Object> responseParams = new HashMap<String, Object>();
-    List<Map<String, String>> publishers = getMultiplePublishers();
-    responseParams.put("publishers", publishers);
-
-    publishers.get(1).put("start", null);
-    String url = url("/titles", BaseEntitlementRegistryClient.mapToPairs(queryParams));
-    Mockito.doReturn(connection(url, 200, "[" + mapToJson(responseParams) + "]")).when(client).openConnection(url);
-    try {
-      client.getPublisher("0123-456X", "20150101", "20151231");
-      fail("Expected exception not thrown");
-    }
-    catch (IOException e) {
-      assertEquals("Multiple matching publishers returned from entitlement registry", e.getMessage());
-    }
-
+    assertEquals(null, client.getPublisher("0123-456X", "11111111-1111-1111-1111-111111111111", "20120101", "20151231"));
     Mockito.verify(client).openConnection(url);
   }
 

--- a/test/src/org/lockss/servlet/TestSafeNetServeContent.java
+++ b/test/src/org/lockss/servlet/TestSafeNetServeContent.java
@@ -238,7 +238,7 @@ public class TestSafeNetServeContent extends LockssServletTestCase {
     pluginMgr.addAu(makeAu());
     Mockito.when(entitlementRegistryClient.getInstitution("ed.ac.uk")).thenReturn("03bd5fc6-97f0-11e4-b270-8932ea886a12");
     Mockito.when(entitlementRegistryClient.isUserEntitled("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn(true);
-    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
+    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
     Mockito.when(entitlementRegistryClient.getPublisherWorkflow("33333333-0000-0000-0000-000000000000")).thenReturn(PublisherWorkflow.PRIMARY_PUBLISHER);
     WebRequest request = new GetMethodWebRequest("http://null/SafeNetServeContent?url=http%3A%2F%2Fdev-safenet.edina.ac.uk%2Ftest_journal%2F" );
     InvocationContext ic = sClient.newInvocation(request);
@@ -258,7 +258,7 @@ public class TestSafeNetServeContent extends LockssServletTestCase {
     pluginMgr.addAu(makeAu());
     Mockito.when(entitlementRegistryClient.getInstitution("ed.ac.uk")).thenReturn("03bd5fc6-97f0-11e4-b270-8932ea886a12");
     Mockito.when(entitlementRegistryClient.isUserEntitled("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn(true);
-    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
+    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
     Mockito.when(entitlementRegistryClient.getPublisherWorkflow("33333333-0000-0000-0000-000000000000")).thenReturn(PublisherWorkflow.PRIMARY_PUBLISHER);
     WebRequest request = new GetMethodWebRequest("http://null/SafeNetServeContent?url=http%3A%2F%2Fdev-safenet.edina.ac.uk%2Ftest_journal%2F" );
     InvocationContext ic = sClient.newInvocation(request);
@@ -278,7 +278,7 @@ public class TestSafeNetServeContent extends LockssServletTestCase {
     pluginMgr.addAu(makeAu());
     Mockito.when(entitlementRegistryClient.getInstitution("ed.ac.uk")).thenReturn("03bd5fc6-97f0-11e4-b270-8932ea886a12");
     Mockito.when(entitlementRegistryClient.isUserEntitled("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn(true);
-    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
+    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
     Mockito.when(entitlementRegistryClient.getPublisherWorkflow("33333333-0000-0000-0000-000000000000")).thenReturn(PublisherWorkflow.PRIMARY_SAFENET);
     WebRequest request = new GetMethodWebRequest("http://null/SafeNetServeContent?url=http%3A%2F%2Fdev-safenet.edina.ac.uk%2Ftest_journal%2F" );
     InvocationContext ic = sClient.newInvocation(request);
@@ -294,7 +294,7 @@ public class TestSafeNetServeContent extends LockssServletTestCase {
     pluginMgr.addAu(makeAu());
     Mockito.when(entitlementRegistryClient.getInstitution("ed.ac.uk")).thenReturn("03bd5fc6-97f0-11e4-b270-8932ea886a12");
     Mockito.when(entitlementRegistryClient.isUserEntitled("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn(true);
-    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
+    Mockito.when(entitlementRegistryClient.getPublisher("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
     Mockito.when(entitlementRegistryClient.getPublisherWorkflow("33333333-0000-0000-0000-000000000000")).thenReturn(PublisherWorkflow.LIBRARY_NOTIFICATION);
     sClient.setExceptionsThrownOnErrorStatus(false);
     WebRequest request = new GetMethodWebRequest("http://null/SafeNetServeContent?url=http%3A%2F%2Fdev-safenet.edina.ac.uk%2Ftest_journal%2F" );
@@ -363,7 +363,7 @@ public class TestSafeNetServeContent extends LockssServletTestCase {
     Mockito.when(entitlementRegistryClient.getInstitution("ed.ac.uk")).thenReturn("03bd5fc6-97f0-11e4-b270-8932ea886a12");
     Mockito.when(entitlementRegistryClient.isUserEntitled("0740-2783", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn(false);
     Mockito.when(entitlementRegistryClient.isUserEntitled("0000-0000", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn(true);
-    Mockito.when(entitlementRegistryClient.getPublisher("0000-0000", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
+    Mockito.when(entitlementRegistryClient.getPublisher("0000-0000", "03bd5fc6-97f0-11e4-b270-8932ea886a12", "20140101", "20141231")).thenReturn("33333333-0000-0000-0000-000000000000");
     Mockito.when(entitlementRegistryClient.getPublisherWorkflow("33333333-0000-0000-0000-00000000000000")).thenReturn(PublisherWorkflow.PRIMARY_PUBLISHER);
     WebRequest request = new GetMethodWebRequest("http://null/SafeNetServeContent?url=http%3A%2F%2Fdev-safenet.edina.ac.uk%2Ftest_journal%2F" );
     InvocationContext ic = sClient.newInvocation(request);


### PR DESCRIPTION
After I updated the entitlement registry to have publishers attached to entitlements rather than titles, I forgot to actually update LOCKSS, so it was still trying to fetch them using the /titles endpoint
